### PR TITLE
fix npusim.sh ccopt-related typo

### DIFF
--- a/npusim.sh
+++ b/npusim.sh
@@ -83,12 +83,12 @@ if [[ $FUNCTIONAL -eq 1 ]]; then
 fi
 
 # Using integer
-if [[ $USE_INTEGER -eq 1 ]]; then
+if [[ $USER_INTEGER -eq 1 ]]; then
     ccopt+=" -DUSER_INTEGER"
 fi
 
 #Using float
-if [[ $USE_FLOAT -eq 1 ]]; then
+if [[ $USER_FLOAT -eq 1 ]]; then
     ccopt +=" -DUSER_FLOAT"
 fi
 


### PR DESCRIPTION
In npusim.sh:
```
# Using integer
USER_INTEGER=1
# Using float 
USER_FLOAT=0
# ...
if [[ $USE_INTEGER -eq 1 ]]; then
    ccopt+=" -DUSER_INTEGER"
fi
if [[ $USE_FLOAT -eq 1 ]]; then
    ccopt +=" -DUSER_FLOAT"
fi
```
USER_INTEGER VS. USE_INTEGER  &&  USE_FLOAT VS. USER_FLOAT conflicts, causing `./npusim.sh build all` failed with data_t.value not found. This PR fixed this issue.